### PR TITLE
add basic dependabot config for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The goal of this PR is to add basic DependaBot config to keep the Go packages up-to-date

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/375